### PR TITLE
prettier configs -> mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "typecheck": "tsc",
-    "format": "prettier -w ./*.js ./*.ts packages",
-    "lint": "eslint ./*.ts ./*.js packages",
+    "format": "prettier -w ./*.ts ./*.mjs packages",
+    "lint": "eslint ./*.ts ./*.mjs packages",
     "publish-devtools": "cd $REPLAY_DIR/devtools && cd packages/shared && npx --yes yalc publish --private && cd ../../packages/protocol && npx yalc publish --private && cd ../../packages/replay-next && npx yalc publish --private",
     "link-devtools": "npx yalc link shared && npx yalc link protocol && npx yalc link replay-next",
     "yalc-devtools": "publish-devtools && link-devtools",

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   semi: true,
   singleQuote: false,
   tabWidth: 2,


### PR DESCRIPTION
prettier doesn't support typescript yet for its config, but we can use .mjs instead of .js to get 'export default'