### PR TITLE
Use annotation data URL in problem description if present

### DIFF
--- a/packages/replay-data/src/recordingData/replayStringUtil.ts
+++ b/packages/replay-data/src/recordingData/replayStringUtil.ts
@@ -26,3 +26,10 @@ export function scanReplayUrl(text: string): {
   return { recordingId, point };
 }
 
+export function scanAnnotationDataUrl(text: string): string | undefined {
+  const match = /https:\/\/static\.replay\.io\/annotate-execution\/.*?.json/.exec(text);
+  if (match) {
+    return match[0];
+  }
+  return undefined;
+}


### PR DESCRIPTION
This adds support to annotate-execution-data to recognize URLs like https://static.replay.io/annotate-execution/annotate-data-2ceab09d-336f-46dd-9a95-0d0e8f1b5f55-3.json in problem descriptions, which contain annotation data to use instead of sending an experimental command.

This supports a workflow for testing different annotation contents with OpenHands using the github workflow without having to develop/deploy the corresponding backend changes.