### PR TITLE
Add support for console errors in execution point analysis result

### DIFF
--- a/packages/cli/commands/annotate-execution-points.ts
+++ b/packages/cli/commands/annotate-execution-points.ts
@@ -118,9 +118,8 @@ export async function annotateExecutionPointsAction(
 
     const analysisResults = await getAnalysisResults(session, recordingId, annotationDataUrl);
 
-    const { point, commentText, reactComponentName } = analysisResults;
+    const { point, commentText, reactComponentName, consoleError } = analysisResults;
     assert(point, "No point found in analysis results");
-    assert(typeof commentText == "string", "No comment text found in analysis results");
 
     // Run annotation script.
     debug(`annotating repo with analysis results...`);
@@ -139,6 +138,7 @@ export async function annotateExecutionPointsAction(
       point,
       commentText,
       reactComponentName,
+      consoleError,
       annotatedRepo: repo.folderPath,
       annotatedLocations,
       startLocation: startLocationStr,

--- a/packages/replay-data/src/analysis/specs/executionPoint.ts
+++ b/packages/replay-data/src/analysis/specs/executionPoint.ts
@@ -51,4 +51,7 @@ export interface ExecutionDataAnalysisResult {
 
   // If the comment is on a React component, the name of the component.
   reactComponentName?: string;
+
+  // If the point is for a console error, the error text.
+  consoleError?: string;
 }


### PR DESCRIPTION
https://github.com/replayio/backend/pull/10504 adds support for using console errors for the execution point instead of comments.